### PR TITLE
Detect for cross-origin, not just cross-domain, iframes when on iOS

### DIFF
--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -218,10 +218,10 @@ FusionPoseSensor.prototype.start = function() {
   this.onMessageCallback_ = this.onMessage_.bind(this);
 
   // Only listen for postMessages if we're in an iOS and embedded inside a cross
-  // domain IFrame. In this case, the polyfill can still work if the containing
+  // origin IFrame. In this case, the polyfill can still work if the containing
   // page sends synthetic devicemotion events. For an example of this, see
-  // iframe-message-sender.js in VR View: https://goo.gl/XDtvFZ
-  if (Util.isIOS() && Util.isInsideCrossDomainIFrame()) {
+  // the iframe example in the repo at `examples/iframe.html`
+  if (Util.isIOS() && Util.isInsideCrossOriginIFrame()) {
     window.addEventListener('message', this.onMessageCallback_);
   }
   window.addEventListener('orientationchange', this.onOrientationChangeCallback_);

--- a/src/util.js
+++ b/src/util.js
@@ -442,30 +442,30 @@ Util.frameDataFromPose = (function() {
   };
 })();
 
-Util.isInsideCrossDomainIFrame = function() {
+// via https://github.com/googlevr/webvr-polyfill/issues/271
+Util.isInsideCrossOriginIFrame = function() {
   var isFramed = (window.self !== window.top);
-  var refDomain = Util.getDomainFromUrl(document.referrer);
-  var thisDomain = Util.getDomainFromUrl(window.location.href);
+  var refOrigin = Util.getOriginFromUrl(document.referrer);
+  var thisOrigin = Util.getOriginFromUrl(window.location.href);
 
-  return isFramed && (refDomain !== thisDomain);
+  return isFramed && (refOrigin !== thisOrigin);
 };
 
-// From http://stackoverflow.com/a/23945027.
-Util.getDomainFromUrl = function(url) {
-  var domain;
-  // Find & remove protocol (http, ftp, etc.) and get domain.
-  if (url.indexOf("://") > -1) {
-    domain = url.split('/')[2];
+// via https://github.com/googlevr/webvr-polyfill/issues/271
+Util.getOriginFromUrl = function(url) {
+  var domainIdx;
+  var protoSepIdx = url.indexOf("://");
+  if (protoSepIdx !== -1) {
+    domainIdx = protoSepIdx + 3;
+  } else {
+    domainIdx = 0;
   }
-  else {
-    domain = url.split('/')[0];
+  var domainEndIdx = url.indexOf('/', domainIdx);
+  if (domainEndIdx === -1) {
+    domainEndIdx = url.length;
   }
-
-  //find & remove port number
-  domain = domain.split(':')[0];
-
-  return domain;
-}
+  return url.substring(0, domainEndIdx)
+};
 
 Util.getQuaternionAngle = function(quat) {
   // angle = 2 * acos(qw)


### PR DESCRIPTION
From https://github.com/googlevr/webvr-polyfill/issues/271; the `window.self !== window.top && window.top.origin !== window.self.origin` solution does not work since the iframe does not have access to `window.top.origin`. Tested with local iframe example on different ports